### PR TITLE
Enable verify functions when Reduction Acceleration is used.

### DIFF
--- a/cuda_hash_lib/sha256.cu
+++ b/cuda_hash_lib/sha256.cu
@@ -18,6 +18,7 @@
 #include <memory.h>
 extern "C" {
 #include "sha256.cuh"
+#include "../merkle_tree.hpp"
 }
 /****************************** MACROS ******************************/
 #define SHA256_BLOCK_SIZE 32            // SHA256 outputs a 32 byte digest
@@ -205,13 +206,6 @@ __global__ void kernel_sha256_hash_cont(BYTE* indata, WORD inlen, BYTE* outdata,
 	cuda_sha256_final(&ctx, out);
 }
 
-// // Indicate the node to be the LEFT or RIGHT child of its parent
-// enum LeftOrRightSib {
-//   NA,
-//   LEFT,
-//   RIGHT
-// };
-
 // A modified version that also store the parent, left, right.
 __global__ void kernel_sha256_hash_link(BYTE* indata, WORD inlen,
                                         BYTE* outdata, WORD n_batch,
@@ -245,6 +239,55 @@ __global__ void kernel_sha256_hash_link(BYTE* indata, WORD inlen,
     dlrs[l_pos] = LEFT;
     dlrs[r_pos] = RIGHT;
 }
+
+
+// Link MerkleNode
+__global__ void kernel_link_merklenode(BYTE* hashes, WORD hash_size,
+                                       unsigned int* dparent,
+                                       unsigned int* dlefts,
+                                       unsigned int* drights,
+                                       LeftOrRightSib* dlrs,
+                                       MerkleNode* nodes,
+                                       MerkleNode* dnodes, WORD n_nodes,
+                                       WORD num_of_leaves)
+{
+	WORD thread = blockIdx.x * blockDim.x + threadIdx.x;
+	if (thread >= n_nodes)
+	{
+		return;
+	}
+	BYTE* hash = hashes + thread * hash_size;
+	MerkleNode* cur_node = dnodes + thread;
+    cur_node->hash = hash;
+    cur_node->parent = nodes + dparent[thread];
+    cur_node->lr = dlrs[thread];
+    cur_node->digest_len = hash_size;
+    if (thread >= num_of_leaves) {
+        cur_node->left = nodes + dlefts[thread];
+        cur_node->right = nodes + drights[thread];
+    } else {
+        cur_node->left = nullptr;
+        cur_node->right = nullptr;
+    }
+}
+
+// // Add to the hashmap
+// __global__ void kernel_add_to_hashmap(BYTE* leaf_hashes, WORD hash_size,
+//                                       MerkleNode* nodes,
+//                                       //unordered_map<string, MerkleNode*> map,
+//                                       WORD num_of_leaves)
+// {
+// 	WORD thread = blockIdx.x * blockDim.x + threadIdx.x;
+// 	if (thread >= num_of_leaves)
+// 	{
+// 		return;
+// 	}
+// 	BYTE* hash = leaf_hashes + thread * hash_size;
+// 	MerkleNode* cur_node = nodes + thread;
+//     std::string hash_str = hash_to_hex_string(hash, hash_size);
+//     //map[hash_str] = cur_node;
+// }
+
 
 extern "C"
 {

--- a/merkle_tree_gpu/merkle_tree_gpu.cu
+++ b/merkle_tree_gpu/merkle_tree_gpu.cu
@@ -544,6 +544,11 @@ MerkleTree::MerkleTree(unsigned char* data, int data_len, Hasher* hasher_,
                                              hasher->hash_length());
         hash_leaf_map[hash_str] = root + i * sizeof(MerkleNode);
       }
+
+      for (const auto& [str, ignore] : hash_leaf_map) {
+        cerr << str << endl;
+      }
+
       return;
     }
 

--- a/merkle_tree_gpu/merkle_tree_gpu.cu
+++ b/merkle_tree_gpu/merkle_tree_gpu.cu
@@ -7,6 +7,16 @@
 #include <openssl/md5.h>
 using namespace std;
 
+#define INFO(msg) \
+    fprintf(stderr, "info: %s:%d: ",__func__, __LINE__); \
+    fprintf(stderr, "%s", msg);
+
+namespace {
+void print_node(MerkleNode* node) {
+  cout << hash_to_hex_string(node->hash, node->digest_len) << endl;
+}
+} // namespace
+
 int BLOCK_SIZE = 1024;
 
 // hash algorithms - GPU versions
@@ -360,7 +370,8 @@ MerkleNode* MerkleTree::make_tree_no_accel(unsigned char* data,
   return make_tree_from_blocks(blocks);
 }
 
-MerkleNode* make_merkle_tree_root(unsigned int arr_size,
+MerkleNode* make_merkle_tree_root(MerkleNode* nodes,
+                                  unsigned int arr_size,
                                   unsigned int num_of_leaves,
                                   unsigned char* hashes,
                                   unsigned int hash_size,
@@ -368,8 +379,6 @@ MerkleNode* make_merkle_tree_root(unsigned int arr_size,
                                   unsigned int* dlefts,
                                   unsigned int* drights,
                                   LeftOrRightSib* dlrs) {
-  // TODO(allenpthuang): nasty choice to allocate memory here
-  MerkleNode *nodes = new MerkleNode[arr_size];
   MerkleNode *dnodes;
   cudaMalloc((void**) &dnodes, arr_size * sizeof(MerkleNode));
   cudaMemset(dnodes, 0, arr_size * sizeof(MerkleNode));
@@ -513,15 +522,13 @@ MerkleNode* MerkleTree::make_tree_gpu_accel(unsigned char* data,
     }
   }
 
-    unsigned int result_size = (dout_right - dout) / hasher->hash_length();
 
-    cudaMemcpy(out, dout, out_bytes, cudaMemcpyDeviceToHost);
-    cudaFree(dout); cudaFree(din);
+  cudaMemcpy(out, dout, out_bytes, cudaMemcpyDeviceToHost);
+  cudaFree(dout);
+  cudaFree(din);
 
-  unsigned char *result_out = out + (dout_right - dout) - hasher->hash_length();
-  MerkleNode* root_node = new MerkleNode(result_out, hasher->hash_length());
-
-  // free memory used by ACCEK_LINK
+  MerkleNode* root_node;
+  // make MerkleTree root and free memory used by ACCEK_LINK
   if ((accel_mask & ACCEL_LINK) == ACCEL_LINK) {
     cudaMemcpy(parents, dparents,
                 arr_size * sizeof(unsigned long), cudaMemcpyDeviceToHost);
@@ -531,7 +538,9 @@ MerkleNode* MerkleTree::make_tree_gpu_accel(unsigned char* data,
                 arr_size * sizeof(unsigned long), cudaMemcpyDeviceToHost);
     cudaMemcpy(lrs, dlrs,
                 arr_size * sizeof(LeftOrRightSib), cudaMemcpyDeviceToHost);
-    root_node = make_merkle_tree_root(result_size, num_of_blocks, out,
+    unsigned int result_size = (dout_right - dout) / hasher->hash_length();
+    MerkleNode *nodes = new MerkleNode[result_size];
+    root_node = make_merkle_tree_root(nodes, result_size, num_of_blocks, out,
                                    hasher->hash_length(),
                                    dparents, dlefts, drights, dlrs);
     cudaFree(dparents);
@@ -539,16 +548,19 @@ MerkleNode* MerkleTree::make_tree_gpu_accel(unsigned char* data,
     cudaFree(drights);
     cudaFree(dlrs);
     // Note(allenpthuang): add leaves to the hashmap for lookup
-      for (unsigned int i = 0; i < num_of_blocks; i++) {
-        string hash_str = hash_to_hex_string(out + i * hasher->hash_length(),
-                                             hasher->hash_length());
-        hash_leaf_map[hash_str] = root + i * sizeof(MerkleNode);
-      }
+    for (unsigned int i = 0; i < num_of_blocks; i++)
+    {
+      string hash_str = hash_to_hex_string(out + i * hasher->hash_length(),
+                                           hasher->hash_length());
+      hash_leaf_map[hash_str] = nodes + i * sizeof(MerkleNode);
+    }
 
-      for (const auto& [str, ignore] : hash_leaf_map) {
-        cerr << str << endl;
-      }
+    // for (const auto& [str, ignore] : hash_leaf_map) {
+    //   cerr << str << endl;
+    // }
   } else { // if ACCEL_LINK is not set, there is no need to keep `out`.
+    unsigned char *result_out = out + (dout_right - dout) - hasher->hash_length();
+    root_node = new MerkleNode(result_out, hasher->hash_length());
     free(out);
   }
 
@@ -588,12 +600,15 @@ void MerkleTree::append(unsigned char* data, int data_len) {
   append(blocks_to_append);
 }
 
+
+
 // return a vector of the pointer to the sibling MerkleNodes along
 // the path to the root.
 vector<MerkleNode *> MerkleTree::find_siblings(MerkleNode *leaf) {
   vector<MerkleNode *> result;
   MerkleNode *cur_node = leaf;
-  while (cur_node->parent != nullptr) {
+  while (cur_node != nullptr && cur_node->parent != nullptr) {
+    print_node(cur_node);
     if (cur_node->lr == LEFT) {
       result.push_back(cur_node->parent->right);
     } else {
@@ -611,15 +626,7 @@ vector<MerkleNode> MerkleTree::find_siblings(string hash_str) {
   }
   MerkleNode *cur_node = hash_leaf_map[hash_str];
 
-  auto sbs = find_siblings(cur_node);
-  cout << "# sbs = " << sbs.size() << endl;
   vector<MerkleNode> result;
-  if (cur_node == nullptr) {
-    cerr << "cur_node is nullptr!" << endl;
-  }
-  if (cur_node->parent == nullptr) {
-    cerr << "cur_node->parent is nullptr!" << endl;
-  }
   while (cur_node != nullptr && cur_node->parent != nullptr) {
     MerkleNode tmp;
     if (cur_node->lr == LEFT) {
@@ -663,7 +670,6 @@ bool MerkleTree::verify(string hash_str) {
   MerkleNode *node = hash_leaf_map[hash_str];
   MerkleNode input = (*node);
   auto siblings = find_siblings(node);
-  cout << "# sbs = " << siblings.size() << endl;
   return verify(input, siblings);
 }
 

--- a/merkle_tree_gpu/merkle_tree_gpu_demo.cu
+++ b/merkle_tree_gpu/merkle_tree_gpu_demo.cu
@@ -51,7 +51,9 @@ int main(int argc, char *argv[]) {
   Blocks blocks(data, data_len);
 
   // make a MerkleTree from data
-  MerkleTree merkle_tree(data, data_len, hasher);
+  // MerkleTree merkle_tree(data, data_len, hasher);
+  unsigned short ACCEL_MASK = ACCEL_CREATION | ACCEL_REDUCTION | ACCEL_LINK;
+  MerkleTree merkle_tree(data, data_len, hasher, ACCEL_MASK);
   cout << "===== Read all at once. =====" << endl;
   cout << "BLOCK_SIZE = " << BLOCK_SIZE << endl;
   merkle_tree.print();

--- a/merkle_tree_gpu/merkle_tree_gpu_demo.cu
+++ b/merkle_tree_gpu/merkle_tree_gpu_demo.cu
@@ -51,7 +51,9 @@ int main(int argc, char *argv[]) {
   Blocks blocks(data, data_len);
 
   // make a MerkleTree from data
-  MerkleTree merkle_tree(data, data_len, hasher);
+  // MerkleTree merkle_tree(data, data_len, hasher);
+  MerkleTree merkle_tree(data, data_len, hasher,
+                         ACCEL_CREATION | ACCEL_REDUCTION | ACCEL_LINK);
   cout << "===== Read all at once. =====" << endl;
   cout << "BLOCK_SIZE = " << BLOCK_SIZE << endl;
   merkle_tree.print();

--- a/merkle_tree_gpu/merkle_tree_gpu_demo.cu
+++ b/merkle_tree_gpu/merkle_tree_gpu_demo.cu
@@ -5,6 +5,10 @@
 
 using namespace std;
 
+void print_node(MerkleNode* node) {
+  cout << hash_to_hex_string(node->hash, node->digest_len) << endl;
+}
+
 int main(int argc, char *argv[]) {
   // Hasher can be SHA_256 or MD_5 at the moment.
   Hasher* hasher = new SHA_256_GPU();
@@ -59,6 +63,24 @@ int main(int argc, char *argv[]) {
   merkle_tree.print();
   cout << "Root hash: ";
   merkle_tree.print_root_hash();
+
+  // cout << "=========== P/L/R pointers testing zone =============" << endl;
+
+  // MerkleNode* root = merkle_tree.root;
+  // cout << "Root" << endl;
+  // print_node(root);
+  // cout << "Left child" << endl;
+  // print_node(root->left);
+  // cout << "Right child" << endl;
+  // print_node(root->right);
+  // cout << "Right child's parent!" << endl;
+  // print_node(root->right->parent);
+  // cout << "Right child's right child!" << endl;
+  // print_node(root->right->right);
+  // cout << "Right child's right child's parent!" << endl;
+  // print_node(root->right->right->parent);
+
+  // cout << "=========== P/L/R ends ==============================" << endl;
 
   int block_idx = 0;
   auto block_to_verify = blocks.blocks()[0];


### PR DESCRIPTION
Note: currently, `hash_left_map` is still populated on the CPU side; therefore, it will slow down the whole `MerkleTree` creation.